### PR TITLE
Potential fix for code scanning alert no. 6: Server-side request forgery

### DIFF
--- a/routes/sentinel.js
+++ b/routes/sentinel.js
@@ -17,6 +17,17 @@ router.post('/sentinel-data', ensureAuthenticated, async (req, res) => {
         const token = await getSentinelToken();
         const requestData = req.body.body;
         const requestURL = req.body.url;
+        
+        // Allow-list of acceptable URLs
+        const allowedURLs = [
+            'https://api.sentinel.example.com/data',
+            'https://api.sentinel.example.com/other-endpoint'
+        ];
+        
+        if (!allowedURLs.includes(requestURL)) {
+            return res.status(400).json({ error: 'Invalid URL' });
+        }
+        
         const response = await fetch(requestURL, {
             method : "POST",
             headers: { 

--- a/routes/sentinel.js
+++ b/routes/sentinel.js
@@ -20,8 +20,7 @@ router.post('/sentinel-data', ensureAuthenticated, async (req, res) => {
         
         // Allow-list of acceptable URLs
         const allowedURLs = [
-            'https://api.sentinel.example.com/data',
-            'https://api.sentinel.example.com/other-endpoint'
+            'https://services.sentinel-hub.com/api/v1/process'
         ];
         
         if (!allowedURLs.includes(requestURL)) {


### PR DESCRIPTION
Potential fix for [https://github.com/gitsimonm/sat_data_demo/security/code-scanning/6](https://github.com/gitsimonm/sat_data_demo/security/code-scanning/6)

To fix the problem, we need to validate and sanitize the `requestURL` to ensure it does not contain malicious input. One effective way is to use an allow-list of acceptable URLs or domains. This ensures that only predefined, safe URLs can be used in the request.

1. Create an allow-list of acceptable URLs or domains.
2. Validate the `requestURL` against this allow-list before making the request.
3. If the `requestURL` is not in the allow-list, return an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
