### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ app.use(session({
 
 app.use(passport.initialize());
 app.use(passport.session());
-// set up rate limiter: maximum of 100 requests per 15 minutes
+
 const limiter = RateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 100, // max 100 requests per windowMs

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ require('./config/passport');
 const { router: authRoutes, isAuthenticated } = require('./routes/auth');
 const sentinelRoutes = require('./routes/sentinel');
 const getSentinelToken = require('./utils/sentinelAuth');
+const RateLimit = require('express-rate-limit');
 
 const app = express();
 
@@ -54,6 +55,12 @@ app.use(session({
 
 app.use(passport.initialize());
 app.use(passport.session());
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
+
 app.use('/auth', authRoutes);
 app.use('/api', sentinelRoutes);
 app.use(express.static(path.join(__dirname, 'dist')));
@@ -74,7 +81,7 @@ app.get('/', (req, res) => {
     res.redirect('/login');
 });
 
-app.get('/content', isAuthenticated, (req, res) => {
+app.get('/content', limiter, isAuthenticated, (req, res) => {
     console.log('Auth check:', req.isAuthenticated());
     res.set({
         'Content-Security-Policy' : "default-src 'self'; img-src 'self' https://tile.openstreetmap.org blob: data:;",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "css-loader": "^7.1.2",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
+        "express-rate-limit": "^7.5.0",
         "express-session": "^1.18.1",
         "html-loader": "^5.1.0",
         "html-webpack-plugin": "^5.6.3",
@@ -1471,6 +1472,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express-session": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
     "style-loader": "^4.0.0",
-    "webpack": "^5.98.0"
+    "webpack": "^5.98.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "webpack-cli": "^6.0.1"


### PR DESCRIPTION
Potential fix for [https://github.com/gitsimonm/sat_data_demo/security/code-scanning/5](https://github.com/gitsimonm/sat_data_demo/security/code-scanning/5)

To fix the problem, we need to introduce a rate-limiting middleware to the Express application. The `express-rate-limit` package is a well-known library for this purpose. We will configure the rate limiter to allow a maximum of 100 requests per 15 minutes and apply it to the `/content` route to prevent abuse.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `index.js` file.
3. Configure the rate limiter with appropriate settings.
4. Apply the rate limiter to the `/content` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
