### PR TITLE
Missing rate limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ app.use((req, res, next) => {
     next();
 });
 
-app.get(['/login', '/login/'], (req, res) => {
+app.get(['/login', '/login/'], limiter, (req, res) => {
     res.sendFile(path.join(__dirname, 'dist/login/login.html'));
 });
 

--- a/routes/sentinel.js
+++ b/routes/sentinel.js
@@ -3,7 +3,14 @@ const axios = require('axios');
 const getSentinelToken = require('../utils/sentinelAuth');
 const fetch = require('node-fetch');
 const router = express.Router();
+const RateLimit = require('express-rate-limit');
+
 router.use(express.json());
+
+const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
 
 // middleware
 function ensureAuthenticated(req, res, next) {
@@ -12,7 +19,7 @@ function ensureAuthenticated(req, res, next) {
 }
 
 // route
-router.post('/sentinel-data', ensureAuthenticated, async (req, res) => {
+router.post('/sentinel-data', limiter, ensureAuthenticated, async (req, res) => {
     try {
         const token = await getSentinelToken();
         const requestData = req.body.body;


### PR DESCRIPTION
Potential fix for [https://github.com/gitsimonm/sat_data_demo/security/code-scanning/3](https://github.com/gitsimonm/sat_data_demo/security/code-scanning/3)

To fix the problem, we need to apply rate limiting to the route handler that serves the login page. This can be done by using the `express-rate-limit` middleware, which is already imported and configured in the code. We will apply the rate limiter to the `/login` route to ensure that it is protected against excessive requests.

- Add the rate limiter middleware to the `/login` route.
- Ensure that the rate limiter is applied before the route handler.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
